### PR TITLE
Fix typo in Migrator.migrate_entity

### DIFF
--- a/lib/hydra_attribute/migrator.rb
+++ b/lib/hydra_attribute/migrator.rb
@@ -60,7 +60,7 @@ module HydraAttribute
         change_table name, options do |t|
           t.integer :hydra_set_id, null: true
         end
-        add_index name, :hydra_set_id, uniqie: false, name: "#{name}_hydra_set_id_index"
+        add_index name, :hydra_set_id, unique: false, name: "#{name}_hydra_set_id_index"
       end
 
       def create_attribute


### PR DESCRIPTION
This was causing the index on hydra_set_id not to be unique for migrated entities.
