### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# hydra_attribute <a href="http://badge.fury.io/rb/hydra_attribute"><img src="https://badge.fury.io/rb/hydra_attribute@2x.png" alt="Gem Version" height="18"></a> [![Build Status](https://travis-ci.org/kostyantyn/hydra_attribute.png)](https://travis-ci.org/kostyantyn/hydra_attribute) [![Coverage Status](https://coveralls.io/repos/kostyantyn/hydra_attribute/badge.png?branch=master)](https://coveralls.io/r/kostyantyn/hydra_attribute?branch=master) [![Code Climate](https://codeclimate.com/github/kostyantyn/hydra_attribute.png)](https://codeclimate.com/github/kostyantyn/hydra_attribute)
+# hydra_attribute 
+
+<a href="http://badge.fury.io/rb/hydra_attribute"><img src="https://badge.fury.io/rb/hydra_attribute@2x.png" alt="Gem Version" height="18"></a> [![Build Status](https://travis-ci.org/kostyantyn/hydra_attribute.png)](https://travis-ci.org/kostyantyn/hydra_attribute) [![Coverage Status](https://coveralls.io/repos/kostyantyn/hydra_attribute/badge.png?branch=master)](https://coveralls.io/r/kostyantyn/hydra_attribute?branch=master) [![Code Climate](https://codeclimate.com/github/kostyantyn/hydra_attribute.png)](https://codeclimate.com/github/kostyantyn/hydra_attribute) [![Inline docs](http://inch-pages.github.io/github/kostyantyn/hydra_attribute.png)](http://inch-pages.github.io/github/kostyantyn/hydra_attribute)
 
 [Demo](http://ec2-54-229-138-34.eu-west-1.compute.amazonaws.com) | [Wiki](https://github.com/kostyantyn/hydra_attribute/wiki) | [RDoc](http://rdoc.info/github/kostyantyn/hydra_attribute)
 


### PR DESCRIPTION
Hi Kostyantyn,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/kostyantyn/hydra_attribute.png)](http://inch-pages.github.io/github/kostyantyn/hydra_attribute)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Hydra is http://inch-pages.github.io/github/kostyantyn/hydra_attribute/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
